### PR TITLE
[AND] 색상선택 - 360도 이미지를 현재 이미지와 가까운 것부터 preload

### DIFF
--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/component/RotateCarImage.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/component/RotateCarImage.kt
@@ -1,5 +1,6 @@
 package com.softeer.mycarchiving.ui.component
 
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -14,9 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,11 +23,9 @@ import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.memory.MemoryCache
 import coil.request.ImageRequest
-import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
-import com.bumptech.glide.integration.compose.GlideImage
 import kotlinx.coroutines.launch
 
-
+private val TAG = "RotateCarImage"
 
 @Composable
 fun RotateCarImage(
@@ -44,20 +41,36 @@ fun RotateCarImage(
         ImageLoader.Builder(context)
             .memoryCache {
                 MemoryCache.Builder(context)
-                    .maxSizePercent(0.25)
+                    .maxSizePercent(0.4)
                     .build()
             }.build()
     }
 
     // image preload
     LaunchedEffect(imagePath) {
-        for (imageNum in 1..60) {
-            launch {
-                imageLoader.enqueue(
-                    ImageRequest.Builder(context)
-                        .data(imagePath.imagePathToUrl(imageNum))
-                        .build()
-                )
+        // 이전 이미지 29개
+        launch {
+            for (imageNum in selectedIndex + 1 until selectedIndex + 30) {
+                launch {
+                    imageLoader.execute(
+                        ImageRequest.Builder(context)
+                            .data(imagePath.imagePathToUrl((imageNum.mod(60)) + 1))
+                            .build()
+                    )
+                }
+            }
+        }
+
+        // 다음 이미지 30개
+        launch {
+            for (imageNum in selectedIndex - 1 downTo  selectedIndex - 30) {
+                launch {
+                    imageLoader.execute(
+                        ImageRequest.Builder(context)
+                            .data(imagePath.imagePathToUrl((imageNum.mod(60)) + 1))
+                            .build()
+                    )
+                }
             }
         }
     }
@@ -65,7 +78,7 @@ fun RotateCarImage(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(260.dp)
+            .height(200.dp)
     ) {
         AsyncImage(
             modifier = Modifier

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selectcolor/SelectColorViewModel.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selectcolor/SelectColorViewModel.kt
@@ -34,7 +34,10 @@ class SelectColorViewModel @Inject constructor(
                         }
                     }
                     is TrimInteriorCarColor -> {
-                        _interiors.value = it.map { dto -> (dto as TrimInteriorCarColor).asColorOptionUiModel() }
+                        _interiors.value = it.map { dto ->
+                            _interiorImageUrls.value = _interiorImageUrls.value + listOf((dto as TrimInteriorCarColor).carImageUrl)
+                            dto.asColorOptionUiModel()
+                        }
                     }
                     else -> {}
                 }
@@ -50,6 +53,9 @@ class SelectColorViewModel @Inject constructor(
 
     private val _imageUrls = MutableStateFlow<List<String>>(emptyList())
     val imageUrls: StateFlow<List<String>> = _imageUrls
+
+    private val _interiorImageUrls = MutableStateFlow<List<String>>(emptyList())
+    val interiorImageUrls: StateFlow<List<String>> = _interiorImageUrls
 
     private val _topImageIndex = MutableStateFlow(0)
     val topImageIndex: StateFlow<Int> = _topImageIndex
@@ -67,7 +73,6 @@ class SelectColorViewModel @Inject constructor(
             } else {
                 (_topImageIndex.value - 1).mod(IMAGE_COUNT)
             }
-        Log.d(TAG, _topImageIndex.value.toString())
     }
 
     fun changeSelectedColor(selected: Int) {


### PR DESCRIPTION
# 📌 TO-DO
* 기존에 `001~060`을 순차적으로 `preload`하던 방식에서, 현재 이미지 인덱스를 기준으로 `preload`
* 만약 현재 `020.png`를 보고 있다면, `019~001` 순서, `021~060` 순서로 두 개의 `preload` job을 동시 시작 하도록 구현
