### PR TITLE
[BE] 태그 조회 기능 구현

### DIFF
--- a/backend/src/main/java/softeer/h9/hey/controller/car/TagController.java
+++ b/backend/src/main/java/softeer/h9/hey/controller/car/TagController.java
@@ -1,0 +1,29 @@
+package softeer.h9.hey.controller.car;
+
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
+import softeer.h9.hey.dto.car.response.TagResponse;
+import softeer.h9.hey.dto.global.response.GlobalResponse;
+import softeer.h9.hey.service.car.TagService;
+
+@RestController
+@RequiredArgsConstructor
+public class TagController {
+
+	private static final int DEFAULT_TOP_NUMBER = 5;
+
+	private final TagService tagService;
+
+	@GetMapping("/car/tag/select-option")
+	public GlobalResponse<TagResponse> getTopTagBySelectOption(@Valid TagBySelectOptionRequest request) {
+		if (request.getLimit() == null) {
+			request.setLimit(DEFAULT_TOP_NUMBER);
+		}
+		return GlobalResponse.ok(tagService.findTopBySelectOptionId(request));
+	}
+}

--- a/backend/src/main/java/softeer/h9/hey/controller/car/TagController.java
+++ b/backend/src/main/java/softeer/h9/hey/controller/car/TagController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import softeer.h9.hey.dto.car.request.TagByExteriorColorIdRequest;
+import softeer.h9.hey.dto.car.request.TagByInteriorColorIdRequest;
 import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
 import softeer.h9.hey.dto.car.response.TagResponse;
 import softeer.h9.hey.dto.global.response.GlobalResponse;
@@ -34,5 +35,13 @@ public class TagController {
 			request.setLimit(DEFAULT_TOP_NUMBER);
 		}
 		return GlobalResponse.ok(tagService.findTopByExteriorColorId(request));
+	}
+
+	@GetMapping("/car/tag/interior-color")
+	public GlobalResponse<TagResponse> getTopTagByInteriorColor(@Valid TagByInteriorColorIdRequest request) {
+		if (request.getLimit() == null) {
+			request.setLimit(DEFAULT_TOP_NUMBER);
+		}
+		return GlobalResponse.ok(tagService.findTopByInteriorColorId(request));
 	}
 }

--- a/backend/src/main/java/softeer/h9/hey/controller/car/TagController.java
+++ b/backend/src/main/java/softeer/h9/hey/controller/car/TagController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import softeer.h9.hey.dto.car.request.TagByExteriorColorIdRequest;
 import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
 import softeer.h9.hey.dto.car.response.TagResponse;
 import softeer.h9.hey.dto.global.response.GlobalResponse;
@@ -25,5 +26,13 @@ public class TagController {
 			request.setLimit(DEFAULT_TOP_NUMBER);
 		}
 		return GlobalResponse.ok(tagService.findTopBySelectOptionId(request));
+	}
+
+	@GetMapping("/car/tag/exterior-color")
+	public GlobalResponse<TagResponse> getTopTagByExteriorColor(@Valid TagByExteriorColorIdRequest request) {
+		if (request.getLimit() == null) {
+			request.setLimit(DEFAULT_TOP_NUMBER);
+		}
+		return GlobalResponse.ok(tagService.findTopByExteriorColorId(request));
 	}
 }

--- a/backend/src/main/java/softeer/h9/hey/dto/car/request/TagByExteriorColorIdRequest.java
+++ b/backend/src/main/java/softeer/h9/hey/dto/car/request/TagByExteriorColorIdRequest.java
@@ -1,0 +1,25 @@
+package softeer.h9.hey.dto.car.request;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class TagByExteriorColorIdRequest {
+	@NotNull(message = "조회 할 id를 입력해주세요.")
+	private Integer id;
+	@Min(value = 0)
+	private Integer limit;
+
+	private TagByExteriorColorIdRequest(final Integer id, final Integer limit) {
+		this.id = id;
+		this.limit = limit;
+	}
+
+	public static TagByExteriorColorIdRequest of(final Integer id, final Integer limit) {
+		return new TagByExteriorColorIdRequest(id, limit);
+	}
+}

--- a/backend/src/main/java/softeer/h9/hey/dto/car/request/TagByInteriorColorIdRequest.java
+++ b/backend/src/main/java/softeer/h9/hey/dto/car/request/TagByInteriorColorIdRequest.java
@@ -1,0 +1,25 @@
+package softeer.h9.hey.dto.car.request;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class TagByInteriorColorIdRequest {
+	@NotNull(message = "조회 할 id를 입력해주세요.")
+	private Integer id;
+	@Min(value = 0)
+	private Integer limit;
+
+	private TagByInteriorColorIdRequest(final Integer id, final Integer limit) {
+		this.id = id;
+		this.limit = limit;
+	}
+
+	public static TagByInteriorColorIdRequest of(final Integer id, final Integer limit) {
+		return new TagByInteriorColorIdRequest(id, limit);
+	}
+}

--- a/backend/src/main/java/softeer/h9/hey/dto/car/request/TagBySelectOptionRequest.java
+++ b/backend/src/main/java/softeer/h9/hey/dto/car/request/TagBySelectOptionRequest.java
@@ -18,4 +18,8 @@ public class TagBySelectOptionRequest {
 		this.id = id;
 		this.limit = limit;
 	}
+
+	public static TagBySelectOptionRequest of(String id, Integer limit) {
+		return new TagBySelectOptionRequest(id, limit);
+	}
 }

--- a/backend/src/main/java/softeer/h9/hey/dto/car/request/TagBySelectOptionRequest.java
+++ b/backend/src/main/java/softeer/h9/hey/dto/car/request/TagBySelectOptionRequest.java
@@ -1,0 +1,21 @@
+package softeer.h9.hey.dto.car.request;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class TagBySelectOptionRequest {
+	@NotNull(message = "조회 할 id를 입력해주세요.")
+	private String id;
+	@Min(value = 0)
+	private Integer limit;
+
+	private TagBySelectOptionRequest(final String id, final Integer limit) {
+		this.id = id;
+		this.limit = limit;
+	}
+}

--- a/backend/src/main/java/softeer/h9/hey/dto/car/response/TagResponse.java
+++ b/backend/src/main/java/softeer/h9/hey/dto/car/response/TagResponse.java
@@ -1,4 +1,17 @@
 package softeer.h9.hey.dto.car.response;
 
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class TagResponse {
+	final List<String> tags;
+
+	public static TagResponse from(List<String> tags) {
+		return new TagResponse(tags);
+	}
 }

--- a/backend/src/main/java/softeer/h9/hey/repository/Car/TagRepository.java
+++ b/backend/src/main/java/softeer/h9/hey/repository/Car/TagRepository.java
@@ -35,6 +35,24 @@ public class TagRepository {
 		return jdbcTemplate.query(sql, params, rowMapper());
 	}
 
+	public List<String> findTopByExteriorColorId(final int id, final int limit) {
+		String sql = "SELECT tag.content "
+			+ "FROM tag "
+			+ "         LEFT JOIN exteriorColor_selectedTag on tag.id = exteriorColor_selectedTag.tag_id "
+			+ "         LEFT JOIN archiving_exteriorColor "
+			+ "                   on exteriorColor_selectedTag.archiving_exteriorColor_id = archiving_exteriorColor.id "
+			+ "WHERE exterior_color_id = :exteriorColorId "
+			+ "GROUP BY tag.id "
+			+ "ORDER BY COUNT(tag.id) DESC "
+			+ "LIMIT :limit";
+
+		SqlParameterSource params = new MapSqlParameterSource()
+			.addValue("exteriorColorId", id)
+			.addValue("limit", limit);
+
+		return jdbcTemplate.query(sql, params, rowMapper());
+	}
+
 	private RowMapper<String> rowMapper() {
 		return (rs, rowNum) -> rs.getString("content");
 	}

--- a/backend/src/main/java/softeer/h9/hey/repository/Car/TagRepository.java
+++ b/backend/src/main/java/softeer/h9/hey/repository/Car/TagRepository.java
@@ -1,0 +1,42 @@
+package softeer.h9.hey.repository.car;
+
+import java.util.List;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class TagRepository {
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+
+	public List<String> findTopByInteriorColorId(final int id, final int limit) {
+		String sql = "SELECT tag.content "
+			+ "FROM tag "
+			+ "         LEFT JOIN interiorColor_selectedTag on tag.id = interiorColor_selectedTag.tag_id "
+			+ "         LEFT JOIN archiving_interiorColor "
+			+ "                   on interiorColor_selectedTag.archiving_interiorColor_id = archiving_interiorColor.id "
+			+ "WHERE interior_color_id = :interiorColorId "
+			+ "GROUP BY tag.id "
+			+ "ORDER BY COUNT(tag.id) DESC "
+			+ "LIMIT :limit";
+
+		SqlParameterSource params = new MapSqlParameterSource()
+			.addValue("interiorColorId", id)
+			.addValue("limit", limit);
+
+		return jdbcTemplate.query(sql, params, rowMapper());
+	}
+
+	private RowMapper<String> rowMapper() {
+		return (rs, rowNum) -> rs.getString("content");
+	}
+
+}

--- a/backend/src/main/java/softeer/h9/hey/repository/Car/TagRepository.java
+++ b/backend/src/main/java/softeer/h9/hey/repository/Car/TagRepository.java
@@ -53,6 +53,24 @@ public class TagRepository {
 		return jdbcTemplate.query(sql, params, rowMapper());
 	}
 
+	public List<String> findTopBySelectOptionId(final String id, final int limit) {
+		String sql = "SELECT tag.content "
+			+ "FROM tag "
+			+ "         LEFT JOIN selectOption_selectedTag on tag.id = selectOption_selectedTag.tag_id "
+			+ "         LEFT JOIN archiving_selectOption "
+			+ "                   on selectOption_selectedTag.archiving_selectOption_id = archiving_selectOption.id "
+			+ "WHERE select_option_id = :selectOptionId "
+			+ "GROUP BY tag.id "
+			+ "ORDER BY COUNT(tag.id) DESC "
+			+ "LIMIT :limit";
+
+		SqlParameterSource params = new MapSqlParameterSource()
+			.addValue("selectOptionId", id)
+			.addValue("limit", limit);
+
+		return jdbcTemplate.query(sql, params, rowMapper());
+	}
+
 	private RowMapper<String> rowMapper() {
 		return (rs, rowNum) -> rs.getString("content");
 	}

--- a/backend/src/main/java/softeer/h9/hey/service/car/TagService.java
+++ b/backend/src/main/java/softeer/h9/hey/service/car/TagService.java
@@ -1,0 +1,21 @@
+package softeer.h9.hey.service.car;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
+import softeer.h9.hey.dto.car.response.TagResponse;
+import softeer.h9.hey.repository.car.TagRepository;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+	private final TagRepository repository;
+
+	public TagResponse findTopBySelectOptionId(TagBySelectOptionRequest request) {
+		String id = request.getId();
+		int limit = request.getLimit();
+
+		return TagResponse.from(repository.findTopBySelectOptionId(id, limit));
+	}
+}

--- a/backend/src/main/java/softeer/h9/hey/service/car/TagService.java
+++ b/backend/src/main/java/softeer/h9/hey/service/car/TagService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import softeer.h9.hey.dto.car.request.TagByExteriorColorIdRequest;
+import softeer.h9.hey.dto.car.request.TagByInteriorColorIdRequest;
 import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
 import softeer.h9.hey.dto.car.response.TagResponse;
 import softeer.h9.hey.repository.car.TagRepository;
@@ -25,5 +26,12 @@ public class TagService {
 		int limit = request.getLimit();
 
 		return TagResponse.from(repository.findTopByExteriorColorId(id, limit));
+	}
+
+	public TagResponse findTopByInteriorColorId(TagByInteriorColorIdRequest request) {
+		int id = request.getId();
+		int limit = request.getLimit();
+
+		return TagResponse.from(repository.findTopByInteriorColorId(id, limit));
 	}
 }

--- a/backend/src/main/java/softeer/h9/hey/service/car/TagService.java
+++ b/backend/src/main/java/softeer/h9/hey/service/car/TagService.java
@@ -3,6 +3,7 @@ package softeer.h9.hey.service.car;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import softeer.h9.hey.dto.car.request.TagByExteriorColorIdRequest;
 import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
 import softeer.h9.hey.dto.car.response.TagResponse;
 import softeer.h9.hey.repository.car.TagRepository;
@@ -17,5 +18,12 @@ public class TagService {
 		int limit = request.getLimit();
 
 		return TagResponse.from(repository.findTopBySelectOptionId(id, limit));
+	}
+
+	public TagResponse findTopByExteriorColorId(TagByExteriorColorIdRequest request) {
+		int id = request.getId();
+		int limit = request.getLimit();
+
+		return TagResponse.from(repository.findTopByExteriorColorId(id, limit));
 	}
 }

--- a/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
+++ b/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
@@ -56,4 +56,23 @@ class TagControllerTest {
 				jsonPath("$.data.tags").isArray()
 			);
 	}
+
+	@DisplayName("내자색상 id에 따라 상위 limit개의 태그를 조회한다.")
+	@Test
+	void getTopTagByInteriorColor() throws Exception {
+		int id = 1;
+		int limit = 5;
+
+		mockMvc.perform(
+				get("/car/tag/interior-color")
+					.param("id", String.valueOf(id))
+					.param("limit", String.valueOf(limit))
+					.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.statusCode").value(200),
+				jsonPath("$.data.tags").exists(),
+				jsonPath("$.data.tags").isArray()
+			);
+	}
 }

--- a/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
+++ b/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
@@ -1,0 +1,40 @@
+package softeer.h9.hey.controller.car;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("Tag Controller 테스트")
+@SpringBootTest
+@AutoConfigureMockMvc
+class TagControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@DisplayName("선택옵션 id에 따라 상위 limit개의 태그를 조회한다.")
+	@Test
+	void getTopTagBySelectOption() throws Exception {
+		String id = "HSS";
+		int limit = 5;
+
+		mockMvc.perform(
+				get("/car/tag/select-option")
+					.param("id", id)
+					.param("limit", String.valueOf(5))
+					.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.statusCode").value(200),
+				jsonPath("$.data.tags").exists(),
+				jsonPath("$.data.tags").isArray()
+			);
+	}
+}

--- a/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
+++ b/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
@@ -28,7 +28,7 @@ class TagControllerTest {
 		mockMvc.perform(
 				get("/car/tag/select-option")
 					.param("id", id)
-					.param("limit", String.valueOf(5))
+					.param("limit", String.valueOf(limit))
 					.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpectAll(

--- a/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
+++ b/backend/src/test/java/softeer/h9/hey/controller/car/TagControllerTest.java
@@ -37,4 +37,23 @@ class TagControllerTest {
 				jsonPath("$.data.tags").isArray()
 			);
 	}
+
+	@DisplayName("외장색상 id에 따라 상위 limit개의 태그를 조회한다.")
+	@Test
+	void getTopTagByExteriorColor() throws Exception {
+		int id = 3;
+		int limit = 5;
+
+		mockMvc.perform(
+				get("/car/tag/exterior-color")
+					.param("id", String.valueOf(id))
+					.param("limit", String.valueOf(limit))
+					.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.statusCode").value(200),
+				jsonPath("$.data.tags").exists(),
+				jsonPath("$.data.tags").isArray()
+			);
+	}
 }

--- a/backend/src/test/java/softeer/h9/hey/repository/Car/TagRepositoryTest.java
+++ b/backend/src/test/java/softeer/h9/hey/repository/Car/TagRepositoryTest.java
@@ -26,4 +26,15 @@ class TagRepositoryTest {
 
 		assertTrue(limit >= tags.size());
 	}
+
+	@Test
+	@DisplayName("외장 색상 id와 limit를 통해 상위 태그를 조회한다.")
+	void findTopByExteriorColorId() {
+		int limit = 3;
+		int exteriorColorId = 1;
+
+		List<String> tags = repository.findTopByExteriorColorId(exteriorColorId, limit);
+
+		assertTrue(limit >= tags.size());
+	}
 }

--- a/backend/src/test/java/softeer/h9/hey/repository/Car/TagRepositoryTest.java
+++ b/backend/src/test/java/softeer/h9/hey/repository/Car/TagRepositoryTest.java
@@ -1,0 +1,29 @@
+package softeer.h9.hey.repository.car;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("Tag Repository 테스트")
+class TagRepositoryTest {
+
+	@Autowired
+	private TagRepository repository;
+
+	@Test
+	@DisplayName("내장 색상 id와 limit를 통해 상위 태그를 조회한다.")
+	void findTopByInteriorColorId() {
+		int limit = 3;
+		int interiorColorId = 1;
+
+		List<String> tags = repository.findTopByInteriorColorId(interiorColorId, limit);
+
+		assertTrue(limit >= tags.size());
+	}
+}

--- a/backend/src/test/java/softeer/h9/hey/repository/Car/TagRepositoryTest.java
+++ b/backend/src/test/java/softeer/h9/hey/repository/Car/TagRepositoryTest.java
@@ -37,4 +37,15 @@ class TagRepositoryTest {
 
 		assertTrue(limit >= tags.size());
 	}
+
+	@Test
+	@DisplayName("선택 옵션 id와 limit를 통해 상위 태그를 조회한다.")
+	void findTopBySelectOptionId() {
+		int limit = 100;
+		String selectOptionId = "CO2";
+
+		List<String> tags = repository.findTopBySelectOptionId(selectOptionId, limit);
+
+		assertTrue(limit >= tags.size());
+	}
 }

--- a/backend/src/test/java/softeer/h9/hey/service/car/TagServiceTest.java
+++ b/backend/src/test/java/softeer/h9/hey/service/car/TagServiceTest.java
@@ -1,0 +1,39 @@
+package softeer.h9.hey.service.car;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
+import softeer.h9.hey.dto.car.response.TagResponse;
+import softeer.h9.hey.repository.car.TagRepository;
+
+class TagServiceTest {
+
+	private final TagRepository tagRepository = Mockito.mock(TagRepository.class);
+
+	private final TagService tagService = new TagService(tagRepository);
+
+	@DisplayName("선택옵션 id에 따라 상위 limit개의 태그들을 조회한다.")
+	@Test
+	void findTopBySelectOptionId() {
+		String id = "HSS";
+		int limit = 3;
+		TagBySelectOptionRequest request = TagBySelectOptionRequest.of(id, limit);
+
+		List<String> targetTags = List.of("펠리세이드 전용",
+			"반려동물🐱",
+			"관리하기 편해요🧹");
+		when(tagRepository.findTopBySelectOptionId(id, limit)).thenReturn(targetTags);
+
+		TagResponse tagResponse = tagService.findTopBySelectOptionId(request);
+		List<String> tags = tagResponse.getTags();
+
+		assertTrue(limit >= tags.size());
+	}
+}

--- a/backend/src/test/java/softeer/h9/hey/service/car/TagServiceTest.java
+++ b/backend/src/test/java/softeer/h9/hey/service/car/TagServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import softeer.h9.hey.dto.car.request.TagByExteriorColorIdRequest;
+import softeer.h9.hey.dto.car.request.TagByInteriorColorIdRequest;
 import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
 import softeer.h9.hey.dto.car.response.TagResponse;
 import softeer.h9.hey.repository.car.TagRepository;
@@ -51,6 +52,24 @@ class TagServiceTest {
 		when(tagRepository.findTopByExteriorColorId(id, limit)).thenReturn(targetTags);
 
 		TagResponse tagResponse = tagService.findTopByExteriorColorId(request);
+		List<String> tags = tagResponse.getTags();
+
+		assertTrue(limit >= tags.size());
+	}
+
+	@DisplayName("내장색상 id에 따라 상위 limit개의 태그들을 조회한다.")
+	@Test
+	void findTopByInteriorColorId() {
+		int id = 1;
+		int limit = 3;
+		TagByInteriorColorIdRequest request = TagByInteriorColorIdRequest.of(id, limit);
+
+		List<String> targetTags = List.of("멋있어요",
+			"세련된 디자인",
+			"트렌디해요");
+		when(tagRepository.findTopByInteriorColorId(id, limit)).thenReturn(targetTags);
+
+		TagResponse tagResponse = tagService.findTopByInteriorColorId(request);
 		List<String> tags = tagResponse.getTags();
 
 		assertTrue(limit >= tags.size());

--- a/backend/src/test/java/softeer/h9/hey/service/car/TagServiceTest.java
+++ b/backend/src/test/java/softeer/h9/hey/service/car/TagServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import softeer.h9.hey.dto.car.request.TagByExteriorColorIdRequest;
 import softeer.h9.hey.dto.car.request.TagBySelectOptionRequest;
 import softeer.h9.hey.dto.car.response.TagResponse;
 import softeer.h9.hey.repository.car.TagRepository;
@@ -32,6 +33,24 @@ class TagServiceTest {
 		when(tagRepository.findTopBySelectOptionId(id, limit)).thenReturn(targetTags);
 
 		TagResponse tagResponse = tagService.findTopBySelectOptionId(request);
+		List<String> tags = tagResponse.getTags();
+
+		assertTrue(limit >= tags.size());
+	}
+
+	@DisplayName("외장색상 id에 따라 상위 limit개의 태그들을 조회한다.")
+	@Test
+	void findTopByExteriorColorId() {
+		int id = 1;
+		int limit = 3;
+		TagByExteriorColorIdRequest request = TagByExteriorColorIdRequest.of(id, limit);
+
+		List<String> targetTags = List.of("멋있어요",
+			"세련된 디자인",
+			"트렌디해요");
+		when(tagRepository.findTopByExteriorColorId(id, limit)).thenReturn(targetTags);
+
+		TagResponse tagResponse = tagService.findTopByExteriorColorId(request);
 		List<String> tags = tagResponse.getTags();
 
 		assertTrue(limit >= tags.size());


### PR DESCRIPTION
# 📌 TO-DO
색상 페이지에서 태그 조회 기능을 구현한다.
색상 페이지에서 태그 조회 기능 테스트를 작성한다.
선택 옵션 페이지에서 태그 조회 기능을 구현한다.
선택 옵션 페이지에서 태그 조회 기능 테스트를 작성한다.


Close #173 
<!-- Close #00 명령어로 작업 이슈를 닫을 수 있습니다. -->
