### PR TITLE
[AND] 내차만들기 화면 진행에 따른 자동차 정보 네트워크 전송

### DIFF
--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/di/DataModule.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/di/DataModule.kt
@@ -2,6 +2,8 @@ package com.softeer.mycarchiving.di
 
 import com.softeer.data.datasource.ArchivingDataSource
 import com.softeer.data.datasource.ArchivingRemoteDataSource
+import com.softeer.data.datasource.MyArchiveDataSource
+import com.softeer.data.datasource.MyArchiveRemoteDataSource
 import com.softeer.data.datasource.SelectColorDataSource
 import com.softeer.data.datasource.SelectColorRemoteDataSource
 import com.softeer.data.datasource.SelectOptionDataSource
@@ -9,14 +11,17 @@ import com.softeer.data.datasource.SelectOptionRemoteDataSource
 import com.softeer.data.datasource.SelectTrimDataSource
 import com.softeer.data.datasource.SelectTrimRemoteDataSource
 import com.softeer.data.network.ArchivingNetworkApi
+import com.softeer.data.network.MyArchiveNetworkApi
 import com.softeer.data.network.SelectColorNetworkApi
 import com.softeer.data.network.SelectOptionNetworkApi
 import com.softeer.data.network.SelectTrimNetworkApi
 import com.softeer.data.repository.ArchivingRepositoryImpl
+import com.softeer.data.repository.MyArchiveRepositoryImpl
 import com.softeer.data.repository.SelectColorRepositoryImpl
 import com.softeer.data.repository.SelectOptionRepositoryImpl
 import com.softeer.data.repository.SelectTrimRepositoryImpl
 import com.softeer.domain.repository.ArchivingRepository
+import com.softeer.domain.repository.MyArchiveRepository
 import com.softeer.domain.repository.SelectColorRepository
 import com.softeer.domain.repository.SelectOptionRepository
 import com.softeer.domain.repository.SelectTrimRepository
@@ -72,5 +77,15 @@ object DataModule {
         archivingRemoteDataSource: ArchivingDataSource
     ): ArchivingRepository =
         ArchivingRepositoryImpl(archivingNetworkApi, archivingRemoteDataSource)
+
+    @Provides
+    @Singleton
+    fun provideMyArchiveRemoteDataSource(myArchiveNetworkApi: MyArchiveNetworkApi): MyArchiveDataSource =
+        MyArchiveRemoteDataSource(myArchiveNetworkApi)
+
+    @Provides
+    @Singleton
+    fun provideMyArchiveRepository(myArchiveRemoteDataSource: MyArchiveDataSource): MyArchiveRepository =
+        MyArchiveRepositoryImpl(myArchiveRemoteDataSource)
 
 }

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/di/MakingCarApiModule.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/di/MakingCarApiModule.kt
@@ -1,5 +1,6 @@
 package com.softeer.mycarchiving.di
 
+import com.softeer.data.network.MyArchiveNetworkApi
 import com.softeer.data.network.SelectColorNetworkApi
 import com.softeer.data.network.SelectOptionNetworkApi
 import com.softeer.data.network.SelectTrimNetworkApi
@@ -28,5 +29,10 @@ object MakingCarApiModule {
     @Singleton
     fun provideSelectOptionNetworkApi(retrofit: Retrofit): SelectOptionNetworkApi =
         retrofit.create(SelectOptionNetworkApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideMyArchiveNetworkApi(retrofit: Retrofit): MyArchiveNetworkApi =
+        retrofit.create(MyArchiveNetworkApi::class.java)
 
 }

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/mapper/TrimOptionUiModelMapper.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/mapper/TrimOptionUiModelMapper.kt
@@ -20,6 +20,7 @@ fun ModelOption.asSelectModelUiModel(): SelectModelUiModel =
 
 fun TrimOption.asUiModel() =
     TrimOptionUiModel(
+        id = id,
         optionName = optionName,
         optionDesc = optionDesc,
         imageUrl = imageUrl,

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/model/TrimOptionUiModel.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/model/TrimOptionUiModel.kt
@@ -1,6 +1,7 @@
 package com.softeer.mycarchiving.model
 
 data class TrimOptionUiModel(
+    val id: Int,
     val optionName: String,
     val optionDesc: String,
     val imageUrl: String,

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/complete/CompleteScreen.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/complete/CompleteScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -45,6 +46,10 @@ fun CompleteRoute(
     val colors by makingCarViewModel.selectedColor.collectAsStateWithLifecycle()
     val selectedTrims by makingCarViewModel.selectedTrim.collectAsStateWithLifecycle()
     val extraOptions by makingCarViewModel.totalExtraOptions.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        makingCarViewModel.saveCarInfo()
+    }
 
     CompleteScreen(
         modifier = modifier,

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selectcolor/SelectColorScreen.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selectcolor/SelectColorScreen.kt
@@ -64,6 +64,13 @@ fun SelectColorRoute(
     val interiorTags by selectColorViewModel.interiorTags.collectAsStateWithLifecycle()
     val selectedColor by makingCarViewModel.selectedColor.collectAsStateWithLifecycle()
 
+    // 방금 전 상태까지 임시 저장
+    LaunchedEffect(screenProgress) {
+        if (mainProgress == TRIM_COLOR) {
+            makingCarViewModel.saveTempCarInfo()
+        }
+    }
+
     LaunchedEffect(key1 = screenProgress, key2 = exteriors, key3 = interiors) {
         val colorOptions = when (mainProgress to screenProgress) {
             TRIM_COLOR to TRIM_EXTERIOR -> exteriors

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selectoption/SelectOptionScreen.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selectoption/SelectOptionScreen.kt
@@ -93,6 +93,9 @@ fun SelectOptionRoute(
 
     LaunchedEffect(screenProgress) {
         viewModel.focusOptionItem(0) // 화면 변할 때마다 focus된 아이템 초기화
+
+        // 방금 전 상태까지 임시 저장
+        sharedViewModel.saveTempCarInfo()
     }
 
     SelectOptionScreen(

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selecttrim/SelectTrimScreen.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selecttrim/SelectTrimScreen.kt
@@ -179,6 +179,7 @@ fun PreviewSelectTrimScreen() {
         screenProgress = 0,
         options = listOf(
             TrimOptionUiModel(
+                id = 0,
                 optionName = "디젤 2.2",
                 optionDesc = "높은 토크로 파워풀한 드라이빙이 가능하며, 차급대비 연비 효율이 우수합니다.",
                 imageUrl = "",
@@ -187,6 +188,7 @@ fun PreviewSelectTrimScreen() {
                 maximumTorque = "45.0/1,750~2,750kgf-m/rpm",
             ),
             TrimOptionUiModel(
+                id = 1,
                 optionName = "가솔린 3.8",
                 optionDesc = "고마력의 우수한 가속 성능을 확보하여, 넉넉하고 안정감 있는 주행이 가능합니다엔진의 진동이 적어 편안하고 조용한 드라이빙 감성을 제공합니다.",
                 imageUrl = "",

--- a/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selecttrim/SelectTrimScreen.kt
+++ b/android/MyCarchiving/app/src/main/java/com/softeer/mycarchiving/ui/makingcar/selecttrim/SelectTrimScreen.kt
@@ -59,6 +59,13 @@ fun SelectTrimRoute(
     val wheels by selectTrimViewModel.wheels.collectAsStateWithLifecycle()
     val selectedTrims by makingCarViewModel.selectedTrim.collectAsStateWithLifecycle()
 
+    // 방금 전 상태까지 임시 저장
+    LaunchedEffect(screenProgress) {
+        if (mainProgress == TRIM_SELECT) {
+            makingCarViewModel.saveTempCarInfo()
+        }
+    }
+
     SelectTrimScreen(
         modifier = modifier,
         screenProgress = screenProgress,

--- a/android/MyCarchiving/data/src/main/java/com/softeer/data/datasource/MyArchiveDataSource.kt
+++ b/android/MyCarchiving/data/src/main/java/com/softeer/data/datasource/MyArchiveDataSource.kt
@@ -1,0 +1,45 @@
+package com.softeer.data.datasource
+
+import android.util.Log
+import com.softeer.data.model.CarInfoBody
+import com.softeer.data.model.CarTempInfoBody
+import com.softeer.data.network.MyArchiveNetworkApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+interface MyArchiveDataSource {
+
+    fun saveTempCarInfo(body: CarTempInfoBody): Flow<Long>
+
+    fun saveCarInfo(body: CarInfoBody): Flow<Long>
+
+}
+
+private val TAG = MyArchiveDataSource::class.simpleName
+
+class MyArchiveRemoteDataSource(
+    private val myArchiveNetworkApi: MyArchiveNetworkApi
+): MyArchiveDataSource {
+
+    override fun saveTempCarInfo(body: CarTempInfoBody): Flow<Long> = flow {
+        val response = myArchiveNetworkApi.saveMyCarTempInfo(body)
+        val myArchiveId = response.body()?.data?.myChivingId
+
+        if (response.isSuccessful && myArchiveId != null) {
+            emit(myArchiveId)
+        } else {
+            emit(-1L)
+        }
+    }
+
+    override fun saveCarInfo(body: CarInfoBody): Flow<Long> = flow {
+        val response = myArchiveNetworkApi.saveMyCarInfo(body)
+        val myArchiveId = response.body()?.data?.myChivingId
+
+        if (response.isSuccessful && myArchiveId != null) {
+            emit(myArchiveId)
+        } else {
+            emit(-1L)
+        }
+    }
+}

--- a/android/MyCarchiving/data/src/main/java/com/softeer/data/mapper/MyArchiveMapper.kt
+++ b/android/MyCarchiving/data/src/main/java/com/softeer/data/mapper/MyArchiveMapper.kt
@@ -1,0 +1,30 @@
+package com.softeer.data.mapper
+
+import com.softeer.data.model.CarInfoBody
+import com.softeer.data.model.CarTempInfoBody
+import com.softeer.domain.model.CarInfo
+import com.softeer.domain.model.CarTempInfo
+
+fun CarTempInfo.asBody(): CarTempInfoBody =
+    CarTempInfoBody(
+        myChivingId = infoId,
+        bodyType = bodyTypeId,
+        wheelType = wheelTypeId,
+        engine = engineId,
+        trim = modelId,
+        exteriorColor = exteriorColorId,
+        interiorColor = interiorColorId,
+        selectOptions = selectOptionsIds
+    )
+
+fun CarInfo.asBody(): CarInfoBody =
+    CarInfoBody(
+        myChivingId = infoId,
+        bodyType = bodyTypeId,
+        wheelType = wheelTypeId,
+        engine = engineId,
+        trim = modelId,
+        exteriorColor = exteriorColorId,
+        interiorColor = interiorColorId,
+        selectOptions = selectOptionsIds
+    )

--- a/android/MyCarchiving/data/src/main/java/com/softeer/data/model/CarInfoBodies.kt
+++ b/android/MyCarchiving/data/src/main/java/com/softeer/data/model/CarInfoBodies.kt
@@ -1,0 +1,45 @@
+package com.softeer.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class CarInfoBody(
+    @SerializedName("contentType")
+    val contentType: String = "application/json",
+    @SerializedName("myChivingId")
+    val myChivingId: Long,
+    @SerializedName("bodyType")
+    val bodyType: Int,
+    @SerializedName("wheelType")
+    val wheelType: Int,
+    @SerializedName("engine")
+    val engine: Int,
+    @SerializedName("trim")
+    val trim: Int,
+    @SerializedName("exteriorColor")
+    val exteriorColor: Int,
+    @SerializedName("interiorColor")
+    val interiorColor: Int,
+    @SerializedName("selectOptions")
+    val selectOptions: List<String>
+)
+
+data class CarTempInfoBody(
+    @SerializedName("contentType")
+    val contentType: String = "application/json",
+    @SerializedName("myChivingId")
+    val myChivingId: Long?,
+    @SerializedName("bodyType")
+    val bodyType: Int?,
+    @SerializedName("wheelType")
+    val wheelType: Int?,
+    @SerializedName("engine")
+    val engine: Int?,
+    @SerializedName("trim")
+    val trim: Int?,
+    @SerializedName("exteriorColor")
+    val exteriorColor: Int?,
+    @SerializedName("interiorColor")
+    val interiorColor: Int?,
+    @SerializedName("selectOptions")
+    val selectOptions: List<String>?
+)

--- a/android/MyCarchiving/data/src/main/java/com/softeer/data/model/CarInfoResponse.kt
+++ b/android/MyCarchiving/data/src/main/java/com/softeer/data/model/CarInfoResponse.kt
@@ -1,0 +1,8 @@
+package com.softeer.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class CarInfoResponse(
+    @SerializedName("myChivingId")
+    val myChivingId: Long
+)

--- a/android/MyCarchiving/data/src/main/java/com/softeer/data/network/MyArchiveNetworkApi.kt
+++ b/android/MyCarchiving/data/src/main/java/com/softeer/data/network/MyArchiveNetworkApi.kt
@@ -1,0 +1,24 @@
+package com.softeer.data.network
+
+import com.softeer.data.model.BaseResponse
+import com.softeer.data.model.CarInfoBody
+import com.softeer.data.model.CarInfoResponse
+import com.softeer.data.model.CarTempInfoBody
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface MyArchiveNetworkApi {
+
+    @POST("/mychiving")
+    suspend fun saveMyCarInfo(
+        @Body carInfo: CarInfoBody
+    ): Response<BaseResponse<CarInfoResponse>>
+
+    @POST("/mychiving/temp")
+    suspend fun saveMyCarTempInfo(
+        @Body carInfo: CarTempInfoBody
+    ): Response<BaseResponse<CarInfoResponse>>
+
+
+}

--- a/android/MyCarchiving/data/src/main/java/com/softeer/data/repository/MyArchiveRepositoryImpl.kt
+++ b/android/MyCarchiving/data/src/main/java/com/softeer/data/repository/MyArchiveRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.softeer.data.repository
+
+import com.softeer.data.datasource.MyArchiveDataSource
+import com.softeer.data.mapper.asBody
+import com.softeer.domain.model.CarInfo
+import com.softeer.domain.model.CarTempInfo
+import com.softeer.domain.repository.MyArchiveRepository
+import kotlinx.coroutines.flow.Flow
+
+class MyArchiveRepositoryImpl(
+    private val archiveRemoteDataSource: MyArchiveDataSource
+) : MyArchiveRepository {
+
+    override fun saveCarInfo(carInfo: CarInfo): Flow<Long> =
+        archiveRemoteDataSource.saveCarInfo(carInfo.asBody())
+
+    override fun saveTempCarInfo(carTempInfo: CarTempInfo): Flow<Long> =
+        archiveRemoteDataSource.saveTempCarInfo(carTempInfo.asBody())
+
+}

--- a/android/MyCarchiving/domain/src/main/java/com/softeer/domain/model/CarInfo.kt
+++ b/android/MyCarchiving/domain/src/main/java/com/softeer/domain/model/CarInfo.kt
@@ -1,0 +1,23 @@
+package com.softeer.domain.model
+
+data class CarInfo(
+    val infoId: Long,
+    val modelId: Int,
+    val bodyTypeId: Int,
+    val wheelTypeId: Int,
+    val engineId: Int,
+    val exteriorColorId: Int,
+    val interiorColorId: Int,
+    val selectOptionsIds: List<String>
+)
+
+data class CarTempInfo(
+    val infoId: Long? = null,
+    val modelId: Int? = null,
+    val bodyTypeId: Int? = null,
+    val wheelTypeId: Int? = null,
+    val engineId: Int? = null,
+    val exteriorColorId: Int? = null,
+    val interiorColorId: Int? = null,
+    val selectOptionsIds: List<String>? = null
+)

--- a/android/MyCarchiving/domain/src/main/java/com/softeer/domain/repository/MyArchiveRepository.kt
+++ b/android/MyCarchiving/domain/src/main/java/com/softeer/domain/repository/MyArchiveRepository.kt
@@ -1,0 +1,13 @@
+package com.softeer.domain.repository
+
+import com.softeer.domain.model.CarInfo
+import com.softeer.domain.model.CarTempInfo
+import kotlinx.coroutines.flow.Flow
+
+interface MyArchiveRepository {
+
+    fun saveCarInfo(carInfo: CarInfo): Flow<Long>
+
+    fun saveTempCarInfo(carTempInfo: CarTempInfo): Flow<Long>
+
+}

--- a/android/MyCarchiving/domain/src/main/java/com/softeer/domain/usecase/makingcar/SaveCarInfoUseCase.kt
+++ b/android/MyCarchiving/domain/src/main/java/com/softeer/domain/usecase/makingcar/SaveCarInfoUseCase.kt
@@ -1,0 +1,13 @@
+package com.softeer.domain.usecase.makingcar
+
+import com.softeer.domain.model.CarInfo
+import com.softeer.domain.repository.MyArchiveRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SaveCarInfoUseCase @Inject constructor(
+    private val myArchiveRepository: MyArchiveRepository
+) {
+    operator fun invoke(carInfo: CarInfo): Flow<Long> =
+        myArchiveRepository.saveCarInfo(carInfo)
+}

--- a/android/MyCarchiving/domain/src/main/java/com/softeer/domain/usecase/makingcar/SaveTempCarInfoUseCase.kt
+++ b/android/MyCarchiving/domain/src/main/java/com/softeer/domain/usecase/makingcar/SaveTempCarInfoUseCase.kt
@@ -1,0 +1,13 @@
+package com.softeer.domain.usecase.makingcar
+
+import com.softeer.domain.model.CarTempInfo
+import com.softeer.domain.repository.MyArchiveRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SaveTempCarInfoUseCase @Inject constructor(
+    private val myArchiveRepository: MyArchiveRepository
+) {
+    operator fun invoke(carTempInfo: CarTempInfo): Flow<Long> =
+        myArchiveRepository.saveTempCarInfo(carTempInfo)
+}


### PR DESCRIPTION
# 📌 TO-DO
* 내차만들기 자동차 정보 저장용 `DataSource` 및 `Repository` 선언
* 자동차 정보 관련 `Entity`, `DTO` 선언
* 화면 진행할 때마다 `LaunchedEffect`에서 `MakingCarViewModel`의 `saveCarInfo`/`saveTempCarInfo` 호출