### PR TITLE
[BE] AccessToken 유효성 검증 API 추가

### DIFF
--- a/backend/src/main/java/softeer/h9/hey/auth/controller/AuthController.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +17,9 @@ import lombok.RequiredArgsConstructor;
 import softeer.h9.hey.auth.dto.request.AccessTokenRequest;
 import softeer.h9.hey.auth.dto.request.JoinRequest;
 import softeer.h9.hey.auth.dto.request.LoginRequest;
+import softeer.h9.hey.auth.dto.request.ValidatedUserRequest;
 import softeer.h9.hey.auth.dto.response.TokenResponse;
+import softeer.h9.hey.auth.dto.response.UserNameResponse;
 import softeer.h9.hey.auth.exception.InvalidTokenException;
 import softeer.h9.hey.auth.exception.JoinException;
 import softeer.h9.hey.auth.exception.LoginException;
@@ -51,6 +54,15 @@ public class AuthController {
 
 		TokenResponse tokenResponse = authService.republishAccessToken(accessTokenRequest);
 		return GlobalResponse.ok(tokenResponse);
+	}
+
+	@GetMapping("/access-token/validate")
+	public GlobalResponse<?> validateToken(HttpServletRequest request) {
+		String token = getValidatedRequest(request);
+		ValidatedUserRequest validatedUserRequest = new ValidatedUserRequest(token);
+
+		UserNameResponse validatedUserNameResponse = authService.getValidatedUser(validatedUserRequest);
+		return GlobalResponse.ok(validatedUserNameResponse);
 	}
 
 	private static String getValidatedRequest(HttpServletRequest request) {

--- a/backend/src/main/java/softeer/h9/hey/auth/controller/AuthController.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController {
 		return GlobalResponse.ok(tokenResponse);
 	}
 
-	@PostMapping("/access-token")
+	@PostMapping("/access-token/reissue")
 	public GlobalResponse<TokenResponse> getAccessToken(HttpServletRequest request) {
 		String refreshToken = getValidatedRequest(request);
 		AccessTokenRequest accessTokenRequest = new AccessTokenRequest(refreshToken);

--- a/backend/src/main/java/softeer/h9/hey/auth/dto/request/ValidatedUserRequest.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/dto/request/ValidatedUserRequest.java
@@ -1,0 +1,10 @@
+package softeer.h9.hey.auth.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ValidatedUserRequest {
+	private final String token;
+}

--- a/backend/src/main/java/softeer/h9/hey/auth/dto/response/UserNameResponse.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/dto/response/UserNameResponse.java
@@ -1,0 +1,10 @@
+package softeer.h9.hey.auth.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserNameResponse {
+	private final String userName;
+}

--- a/backend/src/main/java/softeer/h9/hey/auth/service/AuthService.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/service/AuthService.java
@@ -15,7 +15,9 @@ import softeer.h9.hey.auth.domain.User;
 import softeer.h9.hey.auth.dto.request.AccessTokenRequest;
 import softeer.h9.hey.auth.dto.request.JoinRequest;
 import softeer.h9.hey.auth.dto.request.LoginRequest;
+import softeer.h9.hey.auth.dto.request.ValidatedUserRequest;
 import softeer.h9.hey.auth.dto.response.TokenResponse;
+import softeer.h9.hey.auth.dto.response.UserNameResponse;
 import softeer.h9.hey.auth.exception.InvalidTokenException;
 import softeer.h9.hey.auth.exception.JoinException;
 import softeer.h9.hey.auth.exception.LoginException;
@@ -113,6 +115,12 @@ public class AuthService {
 		}
 		RefreshTokenEntity refreshTokenEntity = optionalRefreshTokenEntity.get();
 		refreshTokenAsyncExecutor.deleteByIdAsync(refreshTokenEntity.getId());
+	}
+
+	public UserNameResponse getValidatedUser(ValidatedUserRequest validatedUserRequest) {
+		String token = validatedUserRequest.getToken();
+		String userName = jwtTokenProvider.getUserNameFromToken(token);
+		return new UserNameResponse(userName);
 	}
 
 	@Scheduled(cron = "0 30 * * * ?")

--- a/backend/src/main/java/softeer/h9/hey/auth/service/AuthService.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/service/AuthService.java
@@ -119,7 +119,8 @@ public class AuthService {
 
 	public UserNameResponse getValidatedUser(ValidatedUserRequest validatedUserRequest) {
 		String token = validatedUserRequest.getToken();
-		String userName = jwtTokenProvider.getUserNameFromToken(token);
+		Map<String, Object> claims = jwtTokenProvider.getClaimsFromToken(token);
+		String userName = (String) claims.get(USER_NAME);
 		return new UserNameResponse(userName);
 	}
 

--- a/backend/src/main/java/softeer/h9/hey/auth/service/JwtTokenProvider.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/service/JwtTokenProvider.java
@@ -88,15 +88,4 @@ public class JwtTokenProvider {
 			throw new InvalidTokenException();
 		}
 	}
-
-	public String getUserNameFromToken(String token) {
-		try {
-			return (String)jwtParser
-				.parseClaimsJws(token)
-				.getBody()
-				.get("userName");
-		} catch (JwtException e) {
-			throw new InvalidTokenException();
-		}
-	}
 }

--- a/backend/src/main/java/softeer/h9/hey/auth/service/JwtTokenProvider.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/service/JwtTokenProvider.java
@@ -88,4 +88,15 @@ public class JwtTokenProvider {
 			throw new InvalidTokenException();
 		}
 	}
+
+	public String getUserNameFromToken(String token) {
+		try {
+			return (String)jwtParser
+				.parseClaimsJws(token)
+				.getBody()
+				.get("userName");
+		} catch (JwtException e) {
+			throw new InvalidTokenException();
+		}
+	}
 }

--- a/backend/src/test/java/softeer/h9/hey/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/softeer/h9/hey/auth/controller/AuthControllerTest.java
@@ -180,4 +180,31 @@ class AuthControllerTest {
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.message").value(InvalidTokenException.INVALID_TOKEN_EXCEPTION));
 	}
+
+	@Test
+	@DisplayName("입력받은 AccessToken이 유효한지 확인하고 유효하다면 userName을 반환한다.")
+	void validateTokenValidateTest() throws Exception {
+		mockMvc.perform(
+				get("/auth/access-token/validate")
+					.contentType(MediaType.APPLICATION_JSON)
+					.header("Authorization",
+						"Bearer eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiIxIiwidXNlck5hbWUiOiJ0ZXN0IiwiaWF0IjoxNjkyNTYwMzM5LCJleHAiOjQ4MTQ2MjQzMzl9.gcSE7kPaRVxo2iT9DRcN1Bn5ZNAAsHG8Z3dvTopH-IWblMf_LJ2lhsYqOvrrLcZJ"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.statusCode").value(200))
+			.andExpect(jsonPath("$.data.userName").value("test"));
+	}
+
+
+	@Test
+	@DisplayName("유효하지 않은 토큰으로 유효성 검증을 요청하면, 401 응답을 내보낸다.")
+	void invalidateTokenValidateTest() throws Exception {
+		mockMvc.perform(
+				get("/auth/access-token/validate")
+					.contentType(MediaType.APPLICATION_JSON)
+					.header("Authorization",
+						"Bearer xx"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.statusCode").value(401))
+			.andExpect(jsonPath("$.message").value(InvalidTokenException.INVALID_TOKEN_EXCEPTION));
+	}
 }

--- a/backend/src/test/java/softeer/h9/hey/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/softeer/h9/hey/auth/controller/AuthControllerTest.java
@@ -159,7 +159,7 @@ class AuthControllerTest {
 		doNothing().when(refreshTokenRepository).deleteById(anyInt());
 
 		mockMvc.perform(
-				post("/auth/access-token")
+				post("/auth/access-token/reissue")
 					.header("Authorization", "Bearer refreshToken"))
 			.andExpect(status().isOk())
 			.andExpectAll(
@@ -174,7 +174,7 @@ class AuthControllerTest {
 	@DisplayName("유효하지 않은 Refresh Token을 헤더에 담아 엑세스 토큰을 요청하면 401 예외를 던진다.")
 	void republishAccessTokenFailTest() throws Exception {
 		mockMvc.perform(
-				post("/auth/access-token")
+				post("/auth/access-token/reissue")
 					.contentType(MediaType.APPLICATION_JSON)
 					.header("Authorization", "Bearer jwttoken12edw"))
 			.andExpect(status().isUnauthorized())

--- a/backend/src/test/java/softeer/h9/hey/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/softeer/h9/hey/auth/service/AuthServiceTest.java
@@ -142,8 +142,8 @@ class AuthServiceTest {
 		String accessToken = "abcdefgh";
 		ValidatedUserRequest validatedUserRequest = new ValidatedUserRequest(accessToken);
 
-		when(tokenProvider.getUserNameFromToken(accessToken))
-			.thenReturn(expectedUserName);
+		when(tokenProvider.getClaimsFromToken(accessToken))
+			.thenReturn(Map.of("userName", expectedUserName));
 
 		UserNameResponse validatedUser = authService.getValidatedUser(validatedUserRequest);
 		String userName = validatedUser.getUserName();

--- a/backend/src/test/java/softeer/h9/hey/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/softeer/h9/hey/auth/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package softeer.h9.hey.auth.service;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
@@ -17,7 +18,9 @@ import softeer.h9.hey.auth.domain.User;
 import softeer.h9.hey.auth.dto.request.AccessTokenRequest;
 import softeer.h9.hey.auth.dto.request.JoinRequest;
 import softeer.h9.hey.auth.dto.request.LoginRequest;
+import softeer.h9.hey.auth.dto.request.ValidatedUserRequest;
 import softeer.h9.hey.auth.dto.response.TokenResponse;
+import softeer.h9.hey.auth.dto.response.UserNameResponse;
 import softeer.h9.hey.auth.exception.JoinException;
 import softeer.h9.hey.auth.exception.LoginException;
 import softeer.h9.hey.auth.repository.RefreshTokenRepository;
@@ -130,5 +133,21 @@ class AuthServiceTest {
 
 		Assertions.assertThat(tokenResponse.getAccessToken()).isNotNull();
 		Assertions.assertThat(tokenResponse.getRefreshToken()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("Access Token으로부터 사용자 이름을 가져오는 기능 테스트")
+	void getValidatedUserNameTest() {
+		String expectedUserName = "expectedUserName";
+		String accessToken = "abcdefgh";
+		ValidatedUserRequest validatedUserRequest = new ValidatedUserRequest(accessToken);
+
+		when(tokenProvider.getUserNameFromToken(accessToken))
+			.thenReturn(expectedUserName);
+
+		UserNameResponse validatedUser = authService.getValidatedUser(validatedUserRequest);
+		String userName = validatedUser.getUserName();
+
+		assertEquals(expectedUserName, userName);
 	}
 }

--- a/backend/src/test/java/softeer/h9/hey/auth/service/JwtTokenProviderTest.java
+++ b/backend/src/test/java/softeer/h9/hey/auth/service/JwtTokenProviderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -63,5 +64,19 @@ class JwtTokenProviderTest {
 
 		assertThatThrownBy(() -> jwtTokenProvider.getClaimsFromToken(jwt))
 			.isInstanceOf(InvalidTokenException.class);
+	}
+
+	@Test
+	@DisplayName("유효한 토큰으로부터 사용자의 이름을 가져온다.")
+	void getValidatedUserNameFromToken() {
+		int userId = 1;
+		String expectedUserName = "name";
+		Map<String, Object> claims = Map.of(USER_NAME, expectedUserName);
+
+		String jwt = jwtTokenProvider.generateAccessToken(userId, claims);
+
+		String actualUserName = jwtTokenProvider.getUserNameFromToken(jwt);
+
+		Assertions.assertEquals(expectedUserName, actualUserName);
 	}
 }

--- a/backend/src/test/java/softeer/h9/hey/auth/service/JwtTokenProviderTest.java
+++ b/backend/src/test/java/softeer/h9/hey/auth/service/JwtTokenProviderTest.java
@@ -65,18 +65,4 @@ class JwtTokenProviderTest {
 		assertThatThrownBy(() -> jwtTokenProvider.getClaimsFromToken(jwt))
 			.isInstanceOf(InvalidTokenException.class);
 	}
-
-	@Test
-	@DisplayName("유효한 토큰으로부터 사용자의 이름을 가져온다.")
-	void getValidatedUserNameFromToken() {
-		int userId = 1;
-		String expectedUserName = "name";
-		Map<String, Object> claims = Map.of(USER_NAME, expectedUserName);
-
-		String jwt = jwtTokenProvider.generateAccessToken(userId, claims);
-
-		String actualUserName = jwtTokenProvider.getUserNameFromToken(jwt);
-
-		Assertions.assertEquals(expectedUserName, actualUserName);
-	}
 }


### PR DESCRIPTION
# 📌 Done
- 토큰의 유효성을 검증하고 토큰에 담긴 유저 이름을 가져오는 기능 구현
- 기존의 AccessToken을 재발급 받는 url 수정

Close #229 