### PR TITLE
[BE] 인과 관련 기능에서 발생하는 CORS 문제 해결

### DIFF
--- a/backend/src/main/java/softeer/h9/hey/auth/web/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/softeer/h9/hey/auth/web/interceptor/AuthInterceptor.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpHeaders.*;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -36,8 +37,13 @@ public class AuthInterceptor implements HandlerInterceptor {
 	private final JwtTokenProvider tokenProvider;
 	private final ObjectMapper objectMapper;
 
+	private final List<String> allowedMethod = List.of("OPTIONS");
+
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		if (allowedMethod.contains(request.getMethod())) {
+			return true;
+		}
 		try {
 			String jwtToken = request.getHeader(AUTHORIZATION).substring(BEARER.length());
 			Map<String, Object> claims = tokenProvider.getClaimsFromToken(jwtToken);


### PR DESCRIPTION
# 📌 Done
브라우저는 동일 출처가 아닌 경우, Options 메서드로 허용된 통신인지 확인한다.
그런데 Option메서드는 인증, 인가에 사용되는 토큰을 Header에 담아 보내지 않기 때문에 CORS문제가 발생했다.
따라서 인증 인가 관련 설정에서 Options 메서드일 경우 인증, 인과 관련 로직을 거치지 않도록 변경했다.

Close #237
