### PR TITLE
[FE] 아카이빙/마이카이빙 페이지 헤더에 사용자명 및 로그아웃 버튼 추가

### DIFF
--- a/frontend/src/components/common/ArchivingHeader/index.tsx
+++ b/frontend/src/components/common/ArchivingHeader/index.tsx
@@ -1,8 +1,15 @@
-import { useLocation, Link } from 'react-router-dom';
+import { useContext } from 'react';
 
-import { ARCHIVING, PATH_LIST } from '@/constants';
+import { useLocation, Link, useNavigate } from 'react-router-dom';
+
+import { ARCHIVING, PATH_LIST, ModalType } from '@/constants';
+import { useModalContext } from '@/hooks/useModalContext';
+import { removeLocalStorage } from '@/utils';
 
 import { HyundaiLogo } from '@/components/common/HyundaiLogo';
+import { AuthContext } from '@/AuthProvider';
+import { PopupModal } from '@/components/common/PopupModal';
+import { ModalPortal } from '@/components/common/ModalPortal';
 
 import * as Styled from './style';
 
@@ -15,6 +22,19 @@ export function ArchivingHeader() {
 
   const isArchivingPage = title === ARCHIVING;
 
+  const { userName, setIsSignin } = useContext(AuthContext);
+
+  const { handleOpen } = useModalContext();
+
+  const navigate = useNavigate();
+
+  function handleSignout() {
+    setIsSignin(false);
+    removeLocalStorage('accessToken');
+    removeLocalStorage('refreshToken');
+    navigate('/', { replace: true });
+  }
+
   return (
     <Styled.Container>
       <Styled.Wrapper>
@@ -22,14 +42,20 @@ export function ArchivingHeader() {
           <HyundaiLogo />
           <Styled.Division />
           <Styled.Text>{title}</Styled.Text>
+          <Styled.CarNameText>팰리세이드</Styled.CarNameText>
         </Styled.Box>
         <Styled.Box>
-          <Styled.CarNameText>팰리세이드</Styled.CarNameText>
+          <Styled.UserNameText>{userName}</Styled.UserNameText>
+          <Styled.GreetingText>님, 안녕하세요!</Styled.GreetingText>
+          <Styled.LogoutButton onClick={handleOpen}>로그아웃</Styled.LogoutButton>
           <Link to={isArchivingPage ? '/mychiving' : '/archiving'}>
             <Styled.Button>{isArchivingPage ? '마이카이빙' : '아카이빙'}</Styled.Button>
           </Link>
         </Styled.Box>
       </Styled.Wrapper>
+      <ModalPortal>
+        <PopupModal type={ModalType.SIGNOUT} onClick={handleSignout} />
+      </ModalPortal>
     </Styled.Container>
   );
 }

--- a/frontend/src/components/common/ArchivingHeader/style.tsx
+++ b/frontend/src/components/common/ArchivingHeader/style.tsx
@@ -87,3 +87,42 @@ export const Button = styled.button`
     `;
   }}
 `;
+
+export const LogoutButton = styled.button`
+  ${({ theme }) => {
+    const { colors, fonts } = theme;
+
+    return css`
+      width: 101.32px;
+      height: 37px;
+
+      color: ${colors.hyundaiNeutral};
+      ${fonts.headingBold4};
+
+      border-radius: 8px;
+      background-color: ${colors.hyundaiPrimaryBlue};
+
+      transform: scale(0.7);
+    `;
+  }}
+`;
+
+export const UserNameText = styled.span`
+  ${({ theme }) => {
+    const { fonts } = theme;
+
+    return css`
+      ${fonts.headingBold4};
+    `;
+  }}
+`;
+
+export const GreetingText = styled.span`
+  ${({ theme }) => {
+    const { fonts } = theme;
+
+    return css`
+      ${fonts.bodyRegular2};
+    `;
+  }}
+`;

--- a/frontend/src/components/common/Header/style.tsx
+++ b/frontend/src/components/common/Header/style.tsx
@@ -120,10 +120,8 @@ const AutoSavingText = styled.span`
 
 const CarNameText = styled.span`
   ${({ theme }) => {
-    const { colors, fonts } = theme;
+    const { fonts } = theme;
     return css`
-      color: ${colors.black};
-
       ${fonts.headingBold4}
     `;
   }}

--- a/frontend/src/components/common/Header/style.tsx
+++ b/frontend/src/components/common/Header/style.tsx
@@ -122,7 +122,7 @@ const CarNameText = styled.span`
   ${({ theme }) => {
     const { colors, fonts } = theme;
     return css`
-      color: ${colors.darkGray};
+      color: ${colors.black};
 
       ${fonts.headingBold4}
     `;


### PR DESCRIPTION
# 📌 TO-DO
- 헤더 팰리세이드 텍스트 색상 다른 텍스트와 일치하는 검은색으로 변경
- 아카이빙/마이카이빙 페이지 헤더에 사용자명 추가
- 아카이빙/마이카이빙 페이지 헤더에 로그아웃 버튼 추가

# 🔍 논의하고 싶은 내용
시간상 리팩토링은 진행하지 못했습니다😢
혹시라도 중복된 부분이 보인다면 수정 부탁드려요

# 🏷️ 기타 사항
Close #252 

<!-- Close #00 명령어로 작업 이슈를 닫을 수 있습니다. -->
